### PR TITLE
Added DEL state for trigger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### NEXT_VERSION_TYPE=MAJOR|MINOR|PATCH
+### NEXT_VERSION_TYPE=MINOR
 ### NEXT_VERSION_DESCRIPTION_BEGIN
+* Added DEL state for trigger.
 ### NEXT_VERSION_DESCRIPTION_END
 ## [2.0.0](https://github.com/yoomoney/moira-kotlin-dsl/pull/1) (15-09-2021)
 

--- a/src/main/kotlin/ru/yoomoney/tech/moira/dsl/triggers/TriggerState.kt
+++ b/src/main/kotlin/ru/yoomoney/tech/moira/dsl/triggers/TriggerState.kt
@@ -23,5 +23,10 @@ enum class TriggerState(val state: String) {
     /**
      * No data available for given trigger.
      */
-    NO_DATA("NODATA")
+    NO_DATA("NODATA"),
+
+    /**
+     * Trigger is in DEL state.
+     */
+    DEL("DEL")
 }


### PR DESCRIPTION
Added DEL state for trigger.

From official docs: "You can also select DEL here to automatically delete all metrics that no longer provide data. A simple use case is when you often rename metrics and Moira quickly becomes flooded with old irrelevant metric names."

https://moira.readthedocs.io/en/latest/user_guide/nodata.html